### PR TITLE
Fix method signature after change in IRB

### DIFF
--- a/lib/awesome_print/custom_defaults.rb
+++ b/lib/awesome_print/custom_defaults.rb
@@ -27,7 +27,7 @@ module AwesomePrint
 
     def usual_rb
       IRB::Irb.class_eval do
-        def output_value
+        def output_value(*args)
           ap @context.last_value
         rescue NoMethodError
           puts "(Object doesn't support #ai)"


### PR DESCRIPTION
This change in IRB changed the method #output_value signature in an incompatible way; fixed

Closes #330